### PR TITLE
Fix crash in editor.js by robustly finding VM instance

### DIFF
--- a/extension/scripts/editor.js
+++ b/extension/scripts/editor.js
@@ -161,8 +161,10 @@ async function onTabLoad() {
 
     // trap vm and store
     let reactInst = Object.values(await getObj('div[class^="stage-wrapper_stage-wrapper_"]')).find((x) => x.child);
-    vm = reactInst.child.child.child.stateNode.props.vm;
-    store = reactInst.child.child.child.stateNode.context.store;
+    let childable = reactInst;
+    while (((childable = childable.child), !childable || !childable.stateNode || !childable.stateNode.props || !childable.stateNode.props.vm));
+    vm = childable.stateNode.props.vm;
+    store = childable.stateNode.context.store;
     addButtonInjectors();
     blId = isNaN(parseFloat(location.pathname.split('/')[2])) ? '' : await getBlocklyId(scratchId); //todo: should this use the result of the getBlId function, or a more specific endpoint to authenticating project joining?
     if(!blId) {
@@ -2860,7 +2862,7 @@ function addButtonInjectors() {
             container.style.display = 'flex';
             container.style.flexDirection = 'column';
 
-            if(!doIOwnThis()) {return;} // if 
+            if(!store || !doIOwnThis()) {return;} // if
             let button = makeLivescratchButton(shareButton);
             livescratchButton = button;
             let dropdown = document.createElement('livescratchDropdown');


### PR DESCRIPTION
The extension was crashing due to a `TypeError` when trying to access `props.vm` on an undefined object. This was caused by a hardcoded traversal of the React component tree, which was not resilient to changes in the Scratch GUI.

This commit fixes the issue by replacing the hardcoded path with a `while` loop that dynamically searches for the correct component instance containing the `vm` object.

Additionally, a guard has been added to the `addButtonInjectors` function to ensure the `store` object is initialized before use, preventing a race condition that was causing a secondary crash.